### PR TITLE
feat(issue-7): Se refactoriza consulta que obtiene las asignaciones historicas de un dispositivo

### DIFF
--- a/src/main/java/com/infragest/infra_devices_service/repository/DeviceAssignmentRepository.java
+++ b/src/main/java/com/infragest/infra_devices_service/repository/DeviceAssignmentRepository.java
@@ -38,10 +38,10 @@ public interface DeviceAssignmentRepository extends JpaRepository<DeviceAssignme
     Optional<DeviceAssignment> findWithLockByDeviceIdAndReleasedAtIsNull(UUID deviceId);
 
     /**
-     * Obtiene todas las asignaciones históricas (released_at IS NOT NULL) de un dispositivo.
+     * Obtiene todas las asignaciones históricas de un dispositivo.
      *
      * @param deviceId ID del dispositivo a consultar.
-     * @return Lista de entidades {@link DeviceAssignment} con asignaciones ya liberadas.
+     * @return Lista de entidades {@link DeviceAssignment} con asignaciones.
      */
-    List<DeviceAssignment> findAllByDeviceIdAndReleasedAtIsNotNullOrderByReleasedAtDesc(UUID deviceId);
+    List<DeviceAssignment> findAllByDeviceIdOrderByAssignedAtDesc(UUID deviceId);
 }

--- a/src/main/java/com/infragest/infra_devices_service/service/impl/DeviceAssignmentServiceImpl.java
+++ b/src/main/java/com/infragest/infra_devices_service/service/impl/DeviceAssignmentServiceImpl.java
@@ -129,7 +129,7 @@ public class DeviceAssignmentServiceImpl implements DeviceAssignmentService {
     public List<DeviceAssignmentDto> getDeviceAssignmentHistory(UUID deviceId) {
 
         // Buscar asignaciones históricas
-        List<DeviceAssignment> assignments = deviceAssignmentRepository.findAllByDeviceIdAndReleasedAtIsNotNullOrderByReleasedAtDesc(deviceId);
+        List<DeviceAssignment> assignments = deviceAssignmentRepository.findAllByDeviceIdOrderByAssignedAtDesc(deviceId);
 
         // Registrar log con el tamaño de las asignaciones encontradas
         log.info("Se encontraron {} asignaciones históricas para el dispositivo {}", assignments.size(), deviceId);


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
- Se modifica consulta que obtiene las asignaciones históricas de un dispositivo en orden descendente incluso las no activas.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?
- Obtener las asignaciones históricas de un dispositivo 

## Checklist
- [ ] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [ ] No hay warnings nuevos
- [ ] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
