### PR TITLE
feat(issue-8): Se refactoriza metodo que consulta la asignacion activa de un device

### DIFF
--- a/src/main/java/com/infragest/infra_devices_service/model/DeviceAssignmentActiveRs.java
+++ b/src/main/java/com/infragest/infra_devices_service/model/DeviceAssignmentActiveRs.java
@@ -1,0 +1,34 @@
+package com.infragest.infra_devices_service.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * DTO para representar el estado de asignación activa de un dispositivo.
+ *
+ * @author bunnystring
+ * @since 2026-02-27
+ * @version 1.0
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeviceAssignmentActiveRs {
+
+    /**
+     * Identificador único del dispositivo a consultar.
+     */
+    private UUID deviceId;
+
+    /**
+     * Indicador de asignación activa.
+     * {@code true} si el dispositivo tiene al menos una asignación activa
+     * (no liberada), {@code false} en caso contrario o si el dispositivo no existe.
+     */
+    private boolean active;
+}

--- a/src/main/java/com/infragest/infra_devices_service/repository/DeviceAssignmentRepository.java
+++ b/src/main/java/com/infragest/infra_devices_service/repository/DeviceAssignmentRepository.java
@@ -44,4 +44,12 @@ public interface DeviceAssignmentRepository extends JpaRepository<DeviceAssignme
      * @return Lista de entidades {@link DeviceAssignment} con asignaciones.
      */
     List<DeviceAssignment> findAllByDeviceIdOrderByAssignedAtDesc(UUID deviceId);
+
+    /**
+     * Obtiene todas las asignaciones activas (con released_at IS NULL) para una lista de dispositivos.
+     *
+     * @param deviceIds Lista de IDs de los dispositivos a consultar.
+     * @return Lista de entidades {@link DeviceAssignment} que tienen una asignación activa para los IDs especificados.
+     */
+    List<DeviceAssignment> findAllByDeviceIdInAndReleasedAtIsNull(List<UUID> deviceIds);
 }

--- a/src/main/java/com/infragest/infra_devices_service/service/DeviceAssignmentService.java
+++ b/src/main/java/com/infragest/infra_devices_service/service/DeviceAssignmentService.java
@@ -2,7 +2,9 @@ package com.infragest.infra_devices_service.service;
 
 import com.infragest.infra_devices_service.entity.DeviceAssignment;
 import com.infragest.infra_devices_service.enums.DeviceStatusEnum;
+import com.infragest.infra_devices_service.model.DeviceAssignmentActiveRs;
 import com.infragest.infra_devices_service.model.DeviceAssignmentDto;
+import com.infragest.infra_devices_service.model.DevicesBatchRq;
 
 import java.util.List;
 import java.util.UUID;
@@ -46,8 +48,8 @@ public interface DeviceAssignmentService {
     /**
      * Verifica si un dispositivo tiene una asignación activa en este momento.
      *
-     * @param deviceId Identificador único del dispositivo.
+     * @param devicesBatchRq Identificador único del dispositivo.
      * @return {@code true} si el dispositivo tiene una asignación activa (releasedAt es null), {@code false} en caso contrario.
      */
-    boolean hasActiveAssignment(UUID deviceId);
+    List<DeviceAssignmentActiveRs> hasActiveAssignment(DevicesBatchRq devicesBatchRq);
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- Se refactoriza el método que verifica si un dispositivo tiene una asignación activa o no, permitiendo ahora consultar múltiples dispositivos en un solo request (batch).
- Se implementan los datos y validaciones necesarios para procesar la consulta y devolver los resultados correctamente en formato batch.

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [ ] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?

- Usar el endpoint batch de verificación de asignaciones activas para dispositivos.
- Probar enviando una lista de UUIDs de dispositivos y validar que la respuesta incluya cada uno con su estado active correspondiente.
- Verificar que los resultados sean correctos tanto para dispositivos con asignación activa como para aquellos sin asignación activa o inexistentes.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
